### PR TITLE
Establish compatibility with 1.17

### DIFF
--- a/stasico/templates/statefulset.yaml
+++ b/stasico/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.persistence.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 {{- else }}
 apiVersion: apps/v1


### PR DESCRIPTION
StatefulSet in apps/v1beta2 has been deprecated since 1.16 and has apparently been removed from 1.17.
It is now in apps/v1.